### PR TITLE
build(deps): update django-weasyprint dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,5 +45,6 @@ gunicorn==22.0.0
 setuptools==70.0.0
 
 weasyprint==62.3
+django_weasyprint==2.3.0
 django-browser-reload==1.13.0
 django-tailwind==3.8.0


### PR DESCRIPTION
- added django_weasyprint==2.3.0 to the project dependencies.
- removed any older or conflicting versions of django_weasyprint if present.

No functional changes or updates to other packages.