### PR TITLE
style(css): update font family to use Google Fonts

### DIFF
--- a/core/static/css/styles.css
+++ b/core/static/css/styles.css
@@ -1,3 +1,9 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+Ethiopic:wght@100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap");
+
+body {
+  font-family: "Noto Sans Ethiopic", "Open Sans", sans-serif;
+}
+
 @page {
   size: A4;
   margin: 10mm;


### PR DESCRIPTION
- added import statement for Google Fonts at the top of the stylesheet.
- changed font-family for the body to use "Noto Sans Ethiopic" and "Open Sans".